### PR TITLE
Added guidelines for handing in receipts

### DIFF
--- a/website/content/reimbursements/contents+en.lr
+++ b/website/content/reimbursements/contents+en.lr
@@ -1,0 +1,75 @@
+title: Submitting Receipts for Reimbursement
+---
+body:
+
+Thank you for supporting our community! To keep our budget healthy and fund more projects, we need receipts that are accepted by the German tax authorities. A rejected receipt means lost VAT — and that money can't go towards future grants.
+
+These guidelines apply to any agreed expenses you'd like to have reimbursed.
+
+## How Much Will You Receive?
+
+Your reimbursement will be the **lower of these two amounts**:
+
+- The **total of your submitted receipts**, or
+- Your **approved amount**
+
+Example: approved for €400 but only spent €280? You'll receive €280.
+
+We want to keep bureaucracy reasonable for everyone. We appreciate every effort to get receipts right and won't expect you to spend excessive time on it.
+
+## Before You Spend — Check This List First
+
+The easiest way to get a valid receipt is to ask the right questions **before** you pay. A few expense types need a little attention upfront.
+
+### Single receipts above €250
+
+For any receipt above €250, make sure an invoice is issued to **Python Software Verband e.V.** using the address below. It's usually easy to arrange at the time of purchase — but very hard to fix afterwards.
+
+### Hotels
+
+Ask the hotel to issue the invoice to **Python Software Verband e.V.** (address below) at check-in. Do this upfront — correcting it afterwards is difficult.
+
+### Restaurants & food
+
+For group meals, one receipt covering everyone is fine. When you submit, please add a note with the number of people, their names, and the occasion.
+
+### Pizza delivery & catering
+
+Same rules as restaurants. If the total exceeds €250, make sure the invoice is addressed to **Python Software Verband e.V.** when placing the order.
+
+### Flights
+
+Your booking confirmation or e-ticket is sufficient — no special action needed.
+
+### Trains
+
+The ticket itself is **not** a valid receipt. You need to request a separate invoice from Deutsche Bahn — this is a [self-service process on their website](https://www.bahn.de/faq/wie-und-wo-bekomme-ich-auf-bahn-de-eine-rechnung-zu-meinem-ticket).
+
+### Invoice address
+
+```
+Python Software Verband e.V.
+p. Adr. Pioneers Hub gGmbH
+Friedrich-Ebert-Anlage 27
+69117 Heidelberg
+Germany
+
+VAT DE287430795
+```
+
+For expenses in Poland only: `PL5263778159`
+
+## What Makes a Receipt Valid?
+
+Two things are required on every receipt, regardless of amount:
+
+1. **The VAT rate shown as a number** — e.g. `7%` or `19%`. Vague phrases like *"prices include statutory VAT"* are not accepted.
+2. **For receipts over €250**: the invoice must additionally name **Python Software Verband e.V.** as the recipient and show the VAT amount as a separate line item.
+
+## How to Submit
+
+1. **One PDF per receipt** — do not merge multiple receipts into a single file.
+2. **Photo quality matters** — a clear, straight-on photo is fine. Please avoid wide-angle shots of the whole table or surroundings.
+3. **Send all receipts in one email to**: **reimbursements@pysv.org**
+
+We aim to process everything within seven working days.

--- a/website/content/reimbursements/contents.lr
+++ b/website/content/reimbursements/contents.lr
@@ -1,0 +1,75 @@
+title: Erstattungen & Fördermittel
+---
+body:
+
+Vielen Dank für dein Engagement in unserer Community! Damit wir unser Budget sinnvoll einsetzen und weitere Projekte fördern können, brauchen wir Belege, die das Finanzamt akzeptiert. Ein abgelehnter Beleg bedeutet verlorene Mehrwertsteuer — und das fehlt uns dann bei der Förderung anderer Projekte.
+
+Diese Hinweise gelten für alle Ausgaben, die wir vorab gemeinsam vereinbart haben.
+
+## Wie viel bekommst du erstattet?
+
+Erstattet wird der **niedrigere** der folgenden zwei Beträge:
+
+- Die **Summe deiner eingereichten Belege**, oder
+- Dein **genehmigter Betrag**
+
+Beispiel: Du hast €400 genehmigt bekommen, aber nur €280 ausgegeben? Du bekommst €280 erstattet.
+
+Wir möchten den Aufwand für alle so gering wie möglich halten — für dich genauso wie für uns. Wir wissen, dass das manchmal fiddelig ist, und erwarten keinen perfekten Beleg um jeden Preis.
+
+## Bevor du zahlst — kurz diese Liste checken
+
+Den einfachsten Weg zu einem gültigen Beleg gibt es schon vor der Zahlung: einfach kurz fragen. Ein paar Ausgabenarten brauchen etwas Aufmerksamkeit im Voraus.
+
+### Einzelbelege über €250
+
+Bei jedem Beleg über €250 muss eine Rechnung auf **Python Software Verband e.V.** ausgestellt werden (Adresse siehe unten). Das klappt meistens problemlos beim Kauf — im Nachhinein ist es oft sehr schwer zu korrigieren.
+
+### Hotels
+
+Bitte beim Check-in direkt darum, die Rechnung auf **Python Software Verband e.V.** (Adresse unten) auszustellen. Unbedingt vor Ort klären — nachträglich ist das kaum möglich.
+
+### Restaurants & Verpflegung
+
+Bei Gruppenessen reicht ein gemeinsamer Beleg für alle. Bitte beim Einreichen kurz notieren: Anzahl der Personen, ihre Namen und Anlass des Essens.
+
+### Pizza-Lieferung & Catering
+
+Gleiche Regeln wie beim Restaurant. Bei Beträgen über €250 bitte beim Bestellen direkt die Rechnungsadresse von **Python Software Verband e.V.** angeben.
+
+### Flüge
+
+Buchungsbestätigung oder E-Ticket reichen aus — hier gibt es nichts Besonderes zu beachten.
+
+### Bahn
+
+Das Ticket selbst ist **kein** gültiger Beleg. Du musst bei der Deutschen Bahn eine separate Rechnung anfordern — das geht bequem [auf ihrer Website](https://www.bahn.de/faq/wie-und-wo-bekomme-ich-auf-bahn-de-eine-rechnung-zu-meinem-ticket).
+
+### Rechnungsadresse
+
+```
+Python Software Verband e.V.
+p. Adr. Pioneers Hub gGmbH
+Friedrich-Ebert-Anlage 27
+69117 Heidelberg
+Germany
+
+USt-IdNr. DE287430795
+```
+
+Nur für Ausgaben in Polen: `PL5263778159`
+
+## Was muss auf dem Beleg stehen?
+
+Zwei Dinge sind auf jedem Beleg Pflicht — unabhängig vom Betrag:
+
+1. **Der Mehrwertsteuersatz als Zahl** — z.B. `7%` oder `19%`. Allgemeine Aussagen wie *„inkl. gesetzlicher MwSt."* werden vom Finanzamt nicht anerkannt.
+2. **Bei Belegen über €250**: Die Rechnung muss zusätzlich **Python Software Verband e.V.** als Empfänger nennen und die Mehrwertsteuer als eigene Position ausweisen.
+
+## So reichst du ein
+
+1. **Ein PDF pro Beleg** — bitte nicht mehrere Belege in einer Datei zusammenfassen.
+2. **Auf Qualität achten** — ein scharfes, gerades Foto reicht völlig. Bitte keine Weitwinkelaufnahmen vom ganzen Tisch oder der Umgebung.
+3. **Alle Belege in einer E-Mail senden an**: **reimbursements@pysv.org**
+
+Wir versuchen, alles innerhalb von sieben Werktagen zu bearbeiten.


### PR DESCRIPTION
**Addition of reimbursement guidelines:**

* Added a detailed English-language guide (`website/content/reimbursements/contents+en.lr`) outlining reimbursement procedures, receipt requirements, and submission instructions, tailored to meet German tax authority standards.
* Added a corresponding German-language guide (`website/content/reimbursements/contents.lr`) with equivalent information, ensuring accessibility for German-speaking community members.#