### PR TITLE
substitute github link to camper tool with current valid address

### DIFF
--- a/content/blog/2026-camper-barcamps/contents+en.lr
+++ b/content/blog/2026-camper-barcamps/contents+en.lr
@@ -39,7 +39,7 @@ Organisers who can contribute to maintenance and hosting costs are warmly welcom
 
 ### Medium term
 
-Parts of Camper still run on older Python versions. A migration to a current Python version is on the roadmap; PySV will involve the open-source community in the process. If you would like to contribute to the development, you can find the project on [GitHub](https://github.com/CampZulu/camper).
+Parts of Camper still run on older Python versions. A migration to a current Python version is on the roadmap; PySV will involve the open-source community in the process. If you would like to contribute to the development, you can find the project on [GitHub](https://github.com/comlounge/camper).
 
 ---
 

--- a/content/blog/2026-camper-barcamps/contents.lr
+++ b/content/blog/2026-camper-barcamps/contents.lr
@@ -39,7 +39,7 @@ Veranstalter, denen ein Beitrag zu Wartung und Hosting möglich ist, freuen wir 
 
 ### Mittelfristig
 
-Camper basiert in Teilen noch auf älteren Python-Versionen. Die Migration auf eine aktuelle Python-Version steht an; der PySV wird die Open-Source-Community in den Prozess einbinden. Wer sich an der Weiterentwicklung beteiligen möchte, findet das Projekt auf [GitHub](https://github.com/CampZulu/camper).
+Camper basiert in Teilen noch auf älteren Python-Versionen. Die Migration auf eine aktuelle Python-Version steht an; der PySV wird die Open-Source-Community in den Prozess einbinden. Wer sich an der Weiterentwicklung beteiligen möchte, findet das Projekt auf [GitHub](https://github.com/comlounge/camper).
 
 ---
 


### PR DESCRIPTION
Former link was broken. Have changed the link to current active one.